### PR TITLE
chore: Configure git and project documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code
+.claude/
+Cowork.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,11 @@ Content pipeline: **Notion → `posts/` or `galleries.json` → Cloudinary → N
 - This ensures clear commit history and gives you opportunity to review changes before merge
 - After merge, the worktree and its branch are deleted
 
+## Collaboration
+
+`Cowork.md` 是 Cowork session 與 Code session 的任務交接文件。
+每次 Code session 開始時，請先讀取 `Cowork.md`，確認是否有待執行的任務，完成後將任務移至「已完成」區塊。
+
 ## Key Conventions
 - Traditional Chinese (繁體中文) content
 - Images served from Cloudinary (`res.cloudinary.com`) — Flickr is being phased out


### PR DESCRIPTION
## Changes

- Ignore `.claude/` directory (Claude Code worktrees and configuration)
- Ignore `Cowork.md` (Cowork session notes and handoff documents)
- Add Branch Strategy section with long-term and short-term branch guidelines
- Add Git Collaboration Workflow documentation
- Add Collaboration section explaining Cowork/Code session handoff process

## Rationale

These changes establish clear git configuration and workflow documentation to ensure:
- Claude Code metadata is not tracked in version control
- Team collaboration follows a consistent branching and PR strategy
- Clear handoff between Cowork and Code sessions