### PR TITLE
feat: 實作 Open API Routes + Swagger UI (TASK-004)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
         "sharp": "^0.34.3",
+        "swagger-jsdoc": "^6.2.8",
         "yet-another-react-lightbox": "^3.24.0"
       },
       "devDependencies": {
@@ -64,6 +65,46 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@emnapi/core": {
@@ -822,6 +863,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1464,7 +1510,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2137,7 +2182,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -2415,7 +2459,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -2451,7 +2494,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2568,6 +2610,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2746,11 +2793,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3668,7 +3722,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3847,6 +3900,11 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4002,6 +4060,26 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -4456,6 +4534,21 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
@@ -5014,7 +5107,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5423,6 +5515,18 @@
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -5434,6 +5538,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6114,7 +6223,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6439,6 +6547,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6553,6 +6675,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -7612,6 +7742,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
@@ -8088,6 +8259,14 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -8245,6 +8424,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -8253,6 +8437,14 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/yet-another-react-lightbox": {
@@ -8289,6 +8481,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
     "sharp": "^0.34.3",
+    "swagger-jsdoc": "^6.2.8",
     "yet-another-react-lightbox": "^3.24.0"
   },
   "devDependencies": {

--- a/src/app/api-docs/page.js
+++ b/src/app/api-docs/page.js
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ApiDocs() {
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css";
+    document.head.appendChild(link);
+
+    const script = document.createElement("script");
+    script.src =
+      "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js";
+    script.onload = () => {
+      window.SwaggerUIBundle({
+        url: "/api/swagger.json",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [
+          window.SwaggerUIBundle.presets.apis,
+          window.SwaggerUIBundle.SwaggerUIStandalonePreset,
+        ],
+        plugins: [window.SwaggerUIBundle.plugins.DownloadUrl],
+        layout: "BaseLayout",
+      });
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(link);
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div
+      style={{ minHeight: "100vh", background: "#fff" }}
+      id="swagger-ui"
+    />
+  );
+}

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -77,12 +77,18 @@
  *                   country:
  *                     type: string
  *                     example: 中國
+ *       400:
+ *         description: 日期格式錯誤（需為 YYYY-MM-DD）
+ *       404:
+ *         description: 查無符合條件的圖庫
  *       500:
  *         description: 伺服器錯誤
  */
 import { getPhotosList } from "@/lib/notion.js";
 
 export const runtime = "nodejs";
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 export async function GET(request) {
   try {
@@ -93,11 +99,19 @@ export async function GET(request) {
     const publishedAfter = searchParams.get("published_after");
     const publishedBefore = searchParams.get("published_before");
 
+    if (publishedAfter && !DATE_REGEX.test(publishedAfter))
+      return Response.json({ error: "published_after 格式錯誤，請使用 YYYY-MM-DD" }, { status: 400 });
+    if (publishedBefore && !DATE_REGEX.test(publishedBefore))
+      return Response.json({ error: "published_before 格式錯誤，請使用 YYYY-MM-DD" }, { status: 400 });
+
     let photos = await getPhotosList();
 
     if (country) photos = photos.filter((p) => p.country === country);
     if (publishedAfter) photos = photos.filter((p) => p.date >= publishedAfter);
     if (publishedBefore) photos = photos.filter((p) => p.date <= publishedBefore);
+
+    if (photos.length === 0)
+      return Response.json({ error: "查無符合條件的圖庫" }, { status: 404 });
 
     photos = photos.sort((a, b) =>
       sort === "oldest"

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -17,7 +17,24 @@
  *         schema:
  *           type: string
  *           enum: [newest, oldest]
- *         description: 排序方式（預設：newest）
+ *         description: 依發布日期排序（預設：newest）
+ *       - in: query
+ *         name: country
+ *         schema:
+ *           type: string
+ *         description: 篩選國家（需完全符合，例如：香港）
+ *       - in: query
+ *         name: published_after
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: 篩選發布日期在此日期之後（含）
+ *       - in: query
+ *         name: published_before
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: 篩選發布日期在此日期之前（含）
  *     responses:
  *       200:
  *         description: 成功取得圖庫列表
@@ -30,30 +47,36 @@
  *                 properties:
  *                   id:
  *                     type: string
- *                     example: photo-001
+ *                     example: Hong-Kong2022
  *                   title:
  *                     type: string
- *                     example: 東京街景
+ *                     example: 2024 香港
  *                   date:
  *                     type: string
  *                     format: date
- *                     example: 2026-01-15
+ *                     example: "2023-02-28"
  *                   description:
  *                     type: string
+ *                     example: 香港・香港
  *                   cover:
  *                     type: string
  *                     format: uri
+ *                     example: https://live.staticflickr.com/65535/54647286995_3b2fc393f0_b.jpg
  *                   category:
  *                     type: string
  *                     enum: [photos]
+ *                     example: photos
  *                   tags:
  *                     type: array
  *                     items:
  *                       type: string
+ *                     example: [攝影, 香港]
  *                   city:
  *                     type: string
+ *                     example: 香港
  *                   country:
  *                     type: string
+ *                     example: 中國
  *       500:
  *         description: 伺服器錯誤
  */
@@ -66,8 +89,15 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.get("limit");
     const sort = searchParams.get("sort") || "newest";
+    const country = searchParams.get("country");
+    const publishedAfter = searchParams.get("published_after");
+    const publishedBefore = searchParams.get("published_before");
 
     let photos = await getPhotosList();
+
+    if (country) photos = photos.filter((p) => p.country === country);
+    if (publishedAfter) photos = photos.filter((p) => p.date >= publishedAfter);
+    if (publishedBefore) photos = photos.filter((p) => p.date <= publishedBefore);
 
     photos = photos.sort((a, b) =>
       sort === "oldest"

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -1,0 +1,85 @@
+/**
+ * @swagger
+ * /api/photos:
+ *   get:
+ *     summary: 取得所有圖庫列表
+ *     description: 返回所有已發佈圖庫（Status != Draft）的摘要清單
+ *     tags:
+ *       - Photos
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *         description: 限制回傳筆數（預設：全部）
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           type: string
+ *           enum: [newest, oldest]
+ *         description: 排序方式（預設：newest）
+ *     responses:
+ *       200:
+ *         description: 成功取得圖庫列表
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: photo-001
+ *                   title:
+ *                     type: string
+ *                     example: 東京街景
+ *                   date:
+ *                     type: string
+ *                     format: date
+ *                     example: 2026-01-15
+ *                   description:
+ *                     type: string
+ *                   cover:
+ *                     type: string
+ *                     format: uri
+ *                   category:
+ *                     type: string
+ *                     enum: [photos]
+ *                   tags:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                   city:
+ *                     type: string
+ *                   country:
+ *                     type: string
+ *       500:
+ *         description: 伺服器錯誤
+ */
+import { getPhotosList } from "@/lib/notion.js";
+
+export const runtime = "nodejs";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.get("limit");
+    const sort = searchParams.get("sort") || "newest";
+
+    let photos = await getPhotosList();
+
+    photos = photos.sort((a, b) =>
+      sort === "oldest"
+        ? new Date(a.date) - new Date(b.date)
+        : new Date(b.date) - new Date(a.date)
+    );
+
+    if (limit) photos = photos.slice(0, parseInt(limit));
+
+    return Response.json(photos);
+  } catch (error) {
+    console.error("Error fetching photos:", error);
+    return Response.json({ error: "Failed to fetch photos" }, { status: 500 });
+  }
+}

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -79,10 +79,37 @@
  *                     example: 中國
  *       400:
  *         description: 日期格式錯誤（需為 YYYY-MM-DD）
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "published_after 格式錯誤，請使用 YYYY-MM-DD"
  *       404:
  *         description: 查無符合條件的圖庫
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "查無符合條件的圖庫"
  *       500:
  *         description: 伺服器錯誤
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "Failed to fetch photos"
  */
 import { getPhotosList } from "@/lib/notion.js";
 

--- a/src/app/api/posts/route.js
+++ b/src/app/api/posts/route.js
@@ -1,0 +1,86 @@
+/**
+ * @swagger
+ * /api/posts:
+ *   get:
+ *     summary: 取得所有文章列表
+ *     description: 返回所有已發佈文章（Status != Draft）的摘要清單
+ *     tags:
+ *       - Posts
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *         description: 限制回傳筆數（預設：全部）
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           type: string
+ *           enum: [newest, oldest]
+ *         description: 排序方式（預設：newest）
+ *     responses:
+ *       200:
+ *         description: 成功取得文章列表
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: post-001
+ *                   title:
+ *                     type: string
+ *                     example: 日本之旅
+ *                   date:
+ *                     type: string
+ *                     format: date
+ *                     example: 2026-01-15
+ *                   description:
+ *                     type: string
+ *                   cover:
+ *                     type: string
+ *                     format: uri
+ *                     example: https://res.cloudinary.com/...
+ *                   category:
+ *                     type: string
+ *                     enum: [trips, essays]
+ *                   tags:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                   city:
+ *                     type: string
+ *                   country:
+ *                     type: string
+ *       500:
+ *         description: 伺服器錯誤
+ */
+import { getPostsList } from "@/lib/notion.js";
+
+export const runtime = "nodejs";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.get("limit");
+    const sort = searchParams.get("sort") || "newest";
+
+    let posts = await getPostsList();
+
+    posts = posts.sort((a, b) =>
+      sort === "oldest"
+        ? new Date(a.date) - new Date(b.date)
+        : new Date(b.date) - new Date(a.date)
+    );
+
+    if (limit) posts = posts.slice(0, parseInt(limit));
+
+    return Response.json(posts);
+  } catch (error) {
+    console.error("Error fetching posts:", error);
+    return Response.json({ error: "Failed to fetch posts" }, { status: 500 });
+  }
+}

--- a/src/app/api/posts/route.js
+++ b/src/app/api/posts/route.js
@@ -83,12 +83,18 @@
  *                   country:
  *                     type: string
  *                     example: 荷蘭
+ *       400:
+ *         description: 日期格式錯誤（需為 YYYY-MM-DD）
+ *       404:
+ *         description: 查無符合條件的文章
  *       500:
  *         description: 伺服器錯誤
  */
 import { getPostsList } from "@/lib/notion.js";
 
 export const runtime = "nodejs";
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 export async function GET(request) {
   try {
@@ -100,12 +106,20 @@ export async function GET(request) {
     const publishedAfter = searchParams.get("published_after");
     const publishedBefore = searchParams.get("published_before");
 
+    if (publishedAfter && !DATE_REGEX.test(publishedAfter))
+      return Response.json({ error: "published_after 格式錯誤，請使用 YYYY-MM-DD" }, { status: 400 });
+    if (publishedBefore && !DATE_REGEX.test(publishedBefore))
+      return Response.json({ error: "published_before 格式錯誤，請使用 YYYY-MM-DD" }, { status: 400 });
+
     let posts = await getPostsList();
 
     if (category) posts = posts.filter((p) => p.category === category);
     if (country) posts = posts.filter((p) => p.country === country);
     if (publishedAfter) posts = posts.filter((p) => p.date >= publishedAfter);
     if (publishedBefore) posts = posts.filter((p) => p.date <= publishedBefore);
+
+    if (posts.length === 0)
+      return Response.json({ error: "查無符合條件的文章" }, { status: 404 });
 
     posts = posts.sort((a, b) =>
       sort === "oldest"

--- a/src/app/api/posts/route.js
+++ b/src/app/api/posts/route.js
@@ -17,7 +17,30 @@
  *         schema:
  *           type: string
  *           enum: [newest, oldest]
- *         description: 排序方式（預設：newest）
+ *         description: 依發布日期排序（預設：newest）
+ *       - in: query
+ *         name: category
+ *         schema:
+ *           type: string
+ *           enum: [trips, essays]
+ *         description: 篩選分類
+ *       - in: query
+ *         name: country
+ *         schema:
+ *           type: string
+ *         description: 篩選國家（需完全符合，例如：荷蘭）
+ *       - in: query
+ *         name: published_after
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: 篩選發布日期在此日期之後（含）
+ *       - in: query
+ *         name: published_before
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: 篩選發布日期在此日期之前（含）
  *     responses:
  *       200:
  *         description: 成功取得文章列表
@@ -30,31 +53,36 @@
  *                 properties:
  *                   id:
  *                     type: string
- *                     example: post-001
+ *                     example: rotterdam-windmill
  *                   title:
  *                     type: string
- *                     example: 日本之旅
+ *                     example: 荷蘭｜鹿特丹小孩堤坊與白色風車
  *                   date:
  *                     type: string
  *                     format: date
- *                     example: 2026-01-15
+ *                     example: "2024-07-09"
  *                   description:
  *                     type: string
+ *                     example: 萊登到鹿特丹，初訪小孩堤坊的多重風車群，騎單車、拍照片與搭公車的日常。
  *                   cover:
  *                     type: string
  *                     format: uri
- *                     example: https://res.cloudinary.com/...
+ *                     example: https://live.staticflickr.com/65535/53976641147_443bbea667_b.jpg
  *                   category:
  *                     type: string
  *                     enum: [trips, essays]
+ *                     example: trips
  *                   tags:
  *                     type: array
  *                     items:
  *                       type: string
+ *                     example: [歐洲, 荷蘭, 鹿特丹, 風車]
  *                   city:
  *                     type: string
+ *                     example: 鹿特丹
  *                   country:
  *                     type: string
+ *                     example: 荷蘭
  *       500:
  *         description: 伺服器錯誤
  */
@@ -67,8 +95,17 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.get("limit");
     const sort = searchParams.get("sort") || "newest";
+    const category = searchParams.get("category");
+    const country = searchParams.get("country");
+    const publishedAfter = searchParams.get("published_after");
+    const publishedBefore = searchParams.get("published_before");
 
     let posts = await getPostsList();
+
+    if (category) posts = posts.filter((p) => p.category === category);
+    if (country) posts = posts.filter((p) => p.country === country);
+    if (publishedAfter) posts = posts.filter((p) => p.date >= publishedAfter);
+    if (publishedBefore) posts = posts.filter((p) => p.date <= publishedBefore);
 
     posts = posts.sort((a, b) =>
       sort === "oldest"

--- a/src/app/api/posts/route.js
+++ b/src/app/api/posts/route.js
@@ -85,10 +85,37 @@
  *                     example: 荷蘭
  *       400:
  *         description: 日期格式錯誤（需為 YYYY-MM-DD）
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "published_after 格式錯誤，請使用 YYYY-MM-DD"
  *       404:
  *         description: 查無符合條件的文章
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "查無符合條件的文章"
  *       500:
  *         description: 伺服器錯誤
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: "Failed to fetch posts"
  */
 import { getPostsList } from "@/lib/notion.js";
 

--- a/src/app/api/swagger.json/route.js
+++ b/src/app/api/swagger.json/route.js
@@ -1,0 +1,7 @@
+import { swaggerSpec } from "@/lib/swagger.js";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json(swaggerSpec);
+}

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -1,0 +1,15 @@
+const cache = new Map();
+const CACHE_TTL = 15 * 60 * 1000;
+
+export function getCache(key) {
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.data;
+  }
+  cache.delete(key);
+  return null;
+}
+
+export function setCache(key, data) {
+  cache.set(key, { data, timestamp: Date.now() });
+}

--- a/src/lib/notion.js
+++ b/src/lib/notion.js
@@ -1,0 +1,93 @@
+import { getCache, setCache } from "./cache.js";
+
+const NOTION_API_KEY = process.env.NOTION_API_KEY;
+const DATABASE_ID = process.env.NOTION_DATABASE_ID;
+
+const HEADERS = {
+  Authorization: `Bearer ${NOTION_API_KEY}`,
+  "Notion-Version": "2022-06-28",
+  "Content-Type": "application/json",
+};
+
+function mapPostPage(page) {
+  const p = page.properties;
+  return {
+    id: p["ID"]?.rich_text[0]?.plain_text || "",
+    title: p["Title"]?.title[0]?.plain_text || "",
+    date: p["Publish Date"]?.date?.start || "",
+    description: p["Description"]?.rich_text[0]?.plain_text || "",
+    cover: p["Cover"]?.url || "",
+    category: p["Category"]?.select?.name || "",
+    tags: p["Tags"]?.multi_select?.map((t) => t.name) || [],
+    city: p["City"]?.select?.name || "",
+    country: p["Country"]?.select?.name || "",
+  };
+}
+
+function mapPhotoPage(page) {
+  const p = page.properties;
+  return {
+    id: p["ID"]?.rich_text[0]?.plain_text || "",
+    title: p["Title"]?.title[0]?.plain_text || "",
+    date: p["Publish Date"]?.date?.start || "",
+    description: p["Description"]?.rich_text[0]?.plain_text || "",
+    cover: p["Cover"]?.url || "",
+    category: "photos",
+    tags: p["Tags"]?.multi_select?.map((t) => t.name) || [],
+    city: p["City"]?.select?.name || "",
+    country: p["Country"]?.select?.name || "",
+  };
+}
+
+async function queryDatabase(typeFilter) {
+  const results = [];
+  let cursor;
+
+  do {
+    const body = {
+      filter: {
+        and: [
+          { property: "Type", select: { equals: typeFilter } },
+          { property: "Status", status: { does_not_equal: "Draft" } },
+        ],
+      },
+      ...(cursor ? { start_cursor: cursor } : {}),
+    };
+
+    const res = await fetch(
+      `https://api.notion.com/v1/databases/${DATABASE_ID}/query`,
+      { method: "POST", headers: HEADERS, body: JSON.stringify(body) }
+    );
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(`Notion API error: ${err.message}`);
+    }
+
+    const data = await res.json();
+    results.push(...data.results);
+    cursor = data.has_more ? data.next_cursor : null;
+  } while (cursor);
+
+  return results;
+}
+
+export async function getPostsList() {
+  const cached = getCache("posts");
+  if (cached) return cached;
+
+  const pages = await queryDatabase("Post");
+  const posts = pages.map(mapPostPage);
+  setCache("posts", posts);
+  return posts;
+}
+
+export async function getPhotosList() {
+  const cached = getCache("photos");
+  if (cached) return cached;
+
+  const pages = await queryDatabase("Photo");
+  const photos = pages.map(mapPhotoPage);
+  setCache("photos", photos);
+  return photos;
+}

--- a/src/lib/swagger.js
+++ b/src/lib/swagger.js
@@ -1,0 +1,26 @@
+import swaggerJsdoc from "swagger-jsdoc";
+import path from "path";
+
+const options = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "backtoblack.blog API",
+      version: "1.0.0",
+      description: "部落格內容 API，提供文章與圖庫資料",
+    },
+    servers: [
+      {
+        url:
+          process.env.NODE_ENV === "production"
+            ? process.env.SITE_URL || "https://backtoblackblog.vercel.app"
+            : "http://localhost:3000",
+        description:
+          process.env.NODE_ENV === "production" ? "Production" : "Development",
+      },
+    ],
+  },
+  apis: [path.join(process.cwd(), "src/app/api/**/*.js")],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);

--- a/src/lib/swagger.js
+++ b/src/lib/swagger.js
@@ -7,7 +7,7 @@ const options = {
     info: {
       title: "backtoblack.blog API",
       version: "1.0.1",
-      description: "部落格內容的 Open API 資源，提供文章與相簿資料",
+      description: "部落格內容的 Open API 資源，提供文章與圖庫資料",
     },
     tags: [{ name: "Posts" }, { name: "Photos" }],
     servers: [

--- a/src/lib/swagger.js
+++ b/src/lib/swagger.js
@@ -6,7 +6,7 @@ const options = {
     openapi: "3.0.0",
     info: {
       title: "backtoblack.blog API",
-      version: "1.0.0",
+      version: "1.0.1",
       description: "部落格內容的 Open API 資源，提供文章與相簿資料",
     },
     tags: [{ name: "Posts" }, { name: "Photos" }],

--- a/src/lib/swagger.js
+++ b/src/lib/swagger.js
@@ -7,8 +7,9 @@ const options = {
     info: {
       title: "backtoblack.blog API",
       version: "1.0.0",
-      description: "部落格內容 API，提供文章與圖庫資料",
+      description: "部落格內容的 Open API 資源，提供文章與相簿資料",
     },
+    tags: [{ name: "Posts" }, { name: "Photos" }],
     servers: [
       {
         url:


### PR DESCRIPTION
## Summary

- 新增 `GET /api/posts` — 從 Notion Database 取得所有已發佈文章，支援 `limit` / `sort` 查詢參數
- 新增 `GET /api/photos` — 從 Notion Database 取得所有已發佈圖庫，支援 `limit` / `sort` 查詢參數
- 新增 `GET /api/swagger.json` — 自動生成 OpenAPI 3.0 規格（由 swagger-jsdoc 掃描 JSDoc 注解）
- 新增 `/api-docs` — 互動式 Swagger UI 頁面（CDN 載入，嵌入 Next.js 頁面）
- 新增 `src/lib/cache.js` — 15 分鐘 in-memory TTL 快取，減少 Notion API 呼叫
- 新增 `src/lib/notion.js` — 封裝 Notion Database 查詢（使用 raw fetch，相容 @notionhq/client v5）

資料源使用既有 `NOTION_DATABASE_ID`，以 `Type`（Post/Photo）+ `Status != Draft` 篩選。

## Test plan

- [x] 啟動 `npm run dev`（需要 Node 18+）
- [x] 瀏覽 `http://localhost:3000/api-docs` 確認 Swagger UI 正常顯示
- [x] 在 Swagger UI 或直接呼叫 `GET /api/posts` 確認回傳 JSON 陣列
- [x] 在 Swagger UI 或直接呼叫 `GET /api/photos` 確認回傳 JSON 陣列
- [x] 測試查詢參數：`?limit=3&sort=oldest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)